### PR TITLE
Fix request slack login workflow

### DIFF
--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -50,10 +50,15 @@ jobs:
               run: |
                 echo "login_url=$(cat login_url.txt)" >> $GITHUB_OUTPUT
                 rm login_url.txt
-                curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+                response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
                        "channel": "@${{ inputs.slack_username }}",
-                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: ${{ steps.generate_login_url.outputs.login_url }}"
+                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
-                     https://slack.com/api/chat.postMessage
+                     https://slack.com/api/chat.postMessage)
+                echo "Slack API response: $response"
+                if [[ $response != *'"ok":true'* ]]; then
+                  echo "Error: Failed to send Slack DM"
+                  exit 1
+                fi

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -54,7 +54,7 @@ jobs:
                      -H "Content-Type: application/json" \
                      -d '{
                        "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
-                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
+                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: ${cat login_url.txt}"
                      }' \
                      https://slack.com/api/chat.postMessage)
                 rm login_url.txt

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -24,18 +24,26 @@ jobs:
                   echo "Error: SFDX_AUTH_URL is not set."
                   exit 1
                 fi
-            - name: Generate Login URL for ${{ inputs.org }}
-              run: d2x sf auth login | tail -1 > login_url.txt
+            - name: Install d2x
+              run: pip install git+https://github.com/muselab-d2x/d2x.git@jlantz/update-auth-structure
+            - id: generate_login_url
+              name: Generate Login URL for ${{ inputs.org }}
               env:
                 SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
-            - name: Send Slack DM
               run: |
-                login_url=$(cat login_url.txt)
+                set -eo pipefail
+                d2x sf auth login | tail -1 > login_url.txt
+            - name: Send Slack DM
+              if: success()
+              env:
+                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+              run: |
+                echo "login_url=$(cat login_url.txt)" >> $GITHUB_OUTPUT
                 rm login_url.txt
-                curl -X POST -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
                        "channel": "@${{ inputs.slack_username }}",
-                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $login_url"
+                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: ${{ steps.generate_login_url.outputs.login_url }}"
                      }' \
                      https://slack.com/api/chat.postMessage

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -54,7 +54,7 @@ jobs:
                      -H "Content-Type: application/json" \
                      -d '{
                        "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
-                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: ${cat login_url.txt}"
+                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
                      https://slack.com/api/chat.postMessage)
                 rm login_url.txt

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - main
+            - jlantz/fix-request-login-url
     workflow_dispatch:
         inputs:
             org:

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -49,14 +49,15 @@ jobs:
                 SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
               run: |
                 echo "login_url=$(cat login_url.txt)" >> $GITHUB_OUTPUT
-                rm login_url.txt
+
                 response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
-                       "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
+                       "channel": "@${{ inputs.slack_username }}",
                        "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
                      https://slack.com/api/chat.postMessage)
+                rm login_url.txt
                 echo "Slack API response: $response"
                 if [[ $response != *'"ok":true'* ]]; then
                   echo "Error: Failed to send Slack DM"

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -1,0 +1,37 @@
+name: Request Org Login Url to Slack DM
+on:
+    workflow_dispatch:
+        inputs:
+            org:
+                description: "The name of the org to get the login URL for. NOTE: Do not select orgs staring with `Snapshot:`"
+                required: true
+                type: environment
+            slack_username:
+                description: "The Slack username to send the DM to"
+                required: true
+                type: string
+jobs:
+    send-login-url:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check SFDX_AUTH_URL
+              run: |
+                if [ -z "${{ secrets.SFDX_AUTH_URL }}" ]; then
+                  echo "Error: SFDX_AUTH_URL is not set."
+                  exit 1
+                fi
+            - name: Generate Login URL for ${{ inputs.org }}
+              run: d2x sf auth login | tail -1 > login_url.txt
+              env:
+                SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+            - name: Send Slack DM
+              run: |
+                login_url=$(cat login_url.txt)
+                rm login_url.txt
+                curl -X POST -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                     -H "Content-Type: application/json" \
+                     -d '{
+                       "channel": "@${{ inputs.slack_username }}",
+                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $login_url"
+                     }' \
+                     https://slack.com/api/chat.postMessage

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -1,31 +1,80 @@
-- name: Send Slack DM
-  if: success()
-  env:
-    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    ORG: ${{ inputs.org }}
-    SLACK_USERNAME: ${{ inputs.slack_username }}
-  run: |
-    set -e
-    login_url=$(cat login_url.txt)
-    echo "login_url=$login_url" >> $GITHUB_OUTPUT
+name: Request Org Login Url to Slack DM
+on:
+  push:
+    branches:
+      - main
+      - jlantz/fix-request-login-url
+  workflow_dispatch:
+    inputs:
+      org:
+        description: "The name of the org to get the login URL for. NOTE: Do not select orgs starting with `Snapshot:`"
+        required: true
+        type: environment
+      slack_username:
+        description: "The Slack username to send the DM to"
+        required: true
+        type: string
 
-    CHANNEL="@${SLACK_USERNAME:-'jasonlantz'}"
-    TEXT="Here is your Salesforce login URL for ${ORG}: ${login_url}"
+jobs:
+  send-login-url:
+    environment: DevHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check SFDX_AUTH_URL
+        run: |
+          if [ -z "${{ secrets.SFDX_AUTH_URL }}" ]; then
+            echo "Error: SFDX_AUTH_URL is not set."
+            exit 1
+          fi
 
-    # Construct JSON data safely
-    JSON_DATA=$(jq -n \
-      --arg channel "$CHANNEL" \
-      --arg text "$TEXT" \
-      '{channel: $channel, text: $text}')
+      - name: Cache d2x
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-         -H "Content-Type: application/json" \
-         -d "$JSON_DATA" \
-         https://slack.com/api/chat.postMessage)
-    rm login_url.txt
-    echo "Slack API response: $response"
-    if [[ $response != *'"ok":true'* ]]; then
-      echo "Error: Failed to send Slack DM"
-      exit 1
-    fi
+      - name: Install d2x
+        run: |
+          pip install git+https://github.com/muselab-d2x/d2x.git@jlantz/update-auth-structure
+          d2x --version | tee -a $GITHUB_STEP_SUMMARY
 
+      - id: generate_login_url
+        name: Generate Login URL for ${{ inputs.org }}
+        env:
+          SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
+        run: |
+          set -eo pipefail
+          d2x sf auth login | tail -1 > login_url.txt
+
+      - name: Send Slack DM
+        if: success()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          ORG: ${{ inputs.org }}
+          SLACK_USERNAME: ${{ inputs.slack_username }}
+        run: |
+          set -e
+          login_url=$(cat login_url.txt)
+          echo "login_url=$login_url" >> $GITHUB_OUTPUT
+
+          CHANNEL="@${SLACK_USERNAME:-'jasonlantz'}"
+          TEXT="Here is your Salesforce login URL for ${ORG}: ${login_url}"
+
+          # Construct JSON data safely
+          JSON_DATA=$(jq -n \
+            --arg channel "$CHANNEL" \
+            --arg text "$TEXT" \
+            '{channel: $channel, text: $text}')
+
+          response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+               -H "Content-Type: application/json" \
+               -d "$JSON_DATA" \
+               https://slack.com/api/chat.postMessage)
+          rm login_url.txt
+          echo "Slack API response: $response"
+          if [[ $response != *'"ok":true'* ]]; then
+            echo "Error: Failed to send Slack DM"
+            exit 1
+          fi

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -26,7 +26,7 @@ jobs:
                   exit 1
                 fi
             - name: Cache d2x
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: ~/.cache/pip
                 key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -1,65 +1,31 @@
-name: Request Org Login Url to Slack DM
-on:
-    push:
-        branches:
-            - main
-            - jlantz/fix-request-login-url
-    workflow_dispatch:
-        inputs:
-            org:
-                description: "The name of the org to get the login URL for. NOTE: Do not select orgs staring with `Snapshot:`"
-                required: true
-                type: environment
-            slack_username:
-                description: "The Slack username to send the DM to"
-                required: true
-                type: string
-jobs:
-    send-login-url:
-        environment: DevHub
-        runs-on: ubuntu-latest
-        steps:
-            - name: Check SFDX_AUTH_URL
-              run: |
-                if [ -z "${{ secrets.SFDX_AUTH_URL }}" ]; then
-                  echo "Error: SFDX_AUTH_URL is not set."
-                  exit 1
-                fi
-            - name: Cache d2x
-              uses: actions/cache@v3
-              with:
-                path: ~/.cache/pip
-                key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-                restore-keys: |
-                  ${{ runner.os }}-pip-
-            - name: Install d2x
-              run: |
-                pip install git+https://github.com/muselab-d2x/d2x.git@jlantz/update-auth-structure
-                d2x --version | tee -a $GITHUB_STEP_SUMMARY
-            - id: generate_login_url
-              name: Generate Login URL for ${{ inputs.org }}
-              env:
-                SFDX_AUTH_URL: ${{ secrets.SFDX_AUTH_URL }}
-              run: |
-                set -eo pipefail
-                d2x sf auth login | tail -1 > login_url.txt
-            - name: Send Slack DM
-              if: success()
-              env:
-                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-              run: |
-                echo "login_url=$(cat login_url.txt)" >> $GITHUB_OUTPUT
+- name: Send Slack DM
+  if: success()
+  env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    ORG: ${{ inputs.org }}
+    SLACK_USERNAME: ${{ inputs.slack_username }}
+  run: |
+    set -e
+    login_url=$(cat login_url.txt)
+    echo "login_url=$login_url" >> $GITHUB_OUTPUT
 
-                response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-                     -H "Content-Type: application/json" \
-                     -d '{
-                       "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
-                       "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
-                     }' \
-                     https://slack.com/api/chat.postMessage)
-                rm login_url.txt
-                echo "Slack API response: $response"
-                if [[ $response != *'"ok":true'* ]]; then
-                  echo "Error: Failed to send Slack DM"
-                  exit 1
-                fi
+    CHANNEL="@${SLACK_USERNAME:-'jasonlantz'}"
+    TEXT="Here is your Salesforce login URL for ${ORG}: ${login_url}"
+
+    # Construct JSON data safely
+    JSON_DATA=$(jq -n \
+      --arg channel "$CHANNEL" \
+      --arg text "$TEXT" \
+      '{channel: $channel, text: $text}')
+
+    response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+         -H "Content-Type: application/json" \
+         -d "$JSON_DATA" \
+         https://slack.com/api/chat.postMessage)
+    rm login_url.txt
+    echo "Slack API response: $response"
+    if [[ $response != *'"ok":true'* ]]; then
+      echo "Error: Failed to send Slack DM"
+      exit 1
+    fi
+

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -25,8 +25,17 @@ jobs:
                   echo "Error: SFDX_AUTH_URL is not set."
                   exit 1
                 fi
+            - name: Cache d2x
+              uses: actions/cache@v2
+              with:
+                path: ~/.cache/pip
+                key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+                restore-keys: |
+                  ${{ runner.os }}-pip-
             - name: Install d2x
-              run: pip install git+https://github.com/muselab-d2x/d2x.git@jlantz/update-auth-structure
+              run: |
+                pip install git+https://github.com/muselab-d2x/d2x.git@jlantz/update-auth-structure
+                d2x --version | tee -a $GITHUB_STEP_SUMMARY
             - id: generate_login_url
               name: Generate Login URL for ${{ inputs.org }}
               env:

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -53,7 +53,7 @@ jobs:
                 response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
-                       "channel": "@${{ inputs.slack_username || "jasonlantz" }}",
+                       "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
                        "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
                      https://slack.com/api/chat.postMessage)

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -53,7 +53,7 @@ jobs:
                 response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
-                       "channel": "@${{ inputs.slack_username }}",
+                       "channel": "@${{ inputs.slack_username || 'jasonlantz' }}",
                        "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
                      https://slack.com/api/chat.postMessage)

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -1,5 +1,8 @@
 name: Request Org Login Url to Slack DM
 on:
+    push:
+        branches:
+            - main
     workflow_dispatch:
         inputs:
             org:

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -16,6 +16,7 @@ on:
                 type: string
 jobs:
     send-login-url:
+        environment: DevHub
         runs-on: ubuntu-latest
         steps:
             - name: Check SFDX_AUTH_URL

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - jlantz/fix-request-login-url
   workflow_dispatch:
     inputs:
       org:
@@ -59,7 +58,7 @@ jobs:
           login_url=$(cat login_url.txt)
           echo "login_url=$login_url" >> $GITHUB_OUTPUT
 
-          CHANNEL="@${SLACK_USERNAME:-'jasonlantz'}"
+          CHANNEL="@${SLACK_USERNAME}"
           TEXT="Here is your Salesforce login URL for ${ORG}: ${login_url}"
 
           # Construct JSON data safely

--- a/.github/workflows/request-login-url.yml
+++ b/.github/workflows/request-login-url.yml
@@ -53,7 +53,7 @@ jobs:
                 response=$(curl -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
                      -H "Content-Type: application/json" \
                      -d '{
-                       "channel": "@${{ inputs.slack_username }}",
+                       "channel": "@${{ inputs.slack_username || "jasonlantz" }}",
                        "text": "Here is your Salesforce login URL for ${{ inputs.org }}: $(cat login_url.txt)"
                      }' \
                      https://slack.com/api/chat.postMessage)

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ You can check the status of your setup by monitoring the status of the following
 * [![2GP Feature Test](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/feature.yml/badge.svg)](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/feature.yml)
 * [![Beta Test](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/beta.yml/badge.svg)](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/beta.yml)
 * [![Production Release](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/release.yml/badge.svg)](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/release.yml)
+
+# Important Note
+The `request-login-url.yml` workflow requires the `SFDX_AUTH_URL` environment variable to be set. Ensure that this variable is correctly configured in your GitHub repository secrets to avoid any issues during the login URL generation process.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ You can check the status of your setup by monitoring the status of the following
 * [![Production Release](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/release.yml/badge.svg)](https://github.com/muselab-d2x/Oh-Snap/actions/workflows/release.yml)
 
 # Important Note
-The `request-login-url.yml` workflow requires the `SFDX_AUTH_URL` environment variable to be set. Ensure that this variable is correctly configured in your GitHub repository secrets to avoid any issues during the login URL generation process.
+The `request-login-url.yml` workflow requires the `SFDX_AUTH_URL` environment variable to be set. Ensure that this variable is correctly configured in your GitHub repository secrets to avoid any issues during the login URL generation process. Additionally, the Slack API token used in the workflow must have the `chat:write:bot` scope to successfully send messages.


### PR DESCRIPTION
Add a check for the `SFDX_AUTH_URL` environment variable in the `request-login-url.yml` workflow.

* **README.md**
  - Add a note about the `SFDX_AUTH_URL` environment variable requirement for the `request-login-url.yml` workflow.

* **.github/workflows/request-login-url.yml**
  - Add a check to ensure the `SFDX_AUTH_URL` environment variable is set before running the `Generate Login URL for` step.
  - Update the `environment` input to be correctly passed to the `d2x` CLI.
  - Ensure the `Generate Login URL for` step fails if the `SFDX_AUTH_URL` is not set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/Oh-Snap?shareId=5d649b2f-171e-4fb1-a820-a24d6d5475e1).